### PR TITLE
Use correct leaderboard data

### DIFF
--- a/logic/conversion/playerToLeaderboardEntry.go
+++ b/logic/conversion/playerToLeaderboardEntry.go
@@ -8,29 +8,34 @@ import (
 	"github.com/fluofoxxo/outrun/obj"
 )
 
-func PlayerToLeaderboardEntry(player netobj.Player) obj.LeaderboardEntry {
-	friendID := player.ID // TODO: is this right?
+func PlayerToLeaderboardEntry(player netobj.Player, mode int64) obj.LeaderboardEntry {
+	friendID := player.ID
 	name := player.Username
 	url := player.Username + "_findme" // TODO: only used for testing right now
-	grade := player.PlayerState.Rank   // TODO: _probably_ what this is, but unsure
+	grade := int64(1) // TODO: make this specifiable in the future (this is the high score ranking it seems)
 	exposeOnline := int64(0)
-	rankingScore := player.PlayerState.HighScore // TODO: this probably differs based on mode...
-	rankChanged := int64(2)
+	rankingScore := player.PlayerState.HighScore
+	rankChanged := int64(0)
 	isSentEnergy := int64(0)
-	expireTime := time.Now().UTC().Unix() + 12345
-	numRank := player.PlayerState.Rank + 1
+	expireTime := now.EndOfWeek().UTC().Unix()
+	numRank := player.PlayerState.Rank
 	loginTime := player.LastLogin
 	mainCharaID := player.PlayerState.MainCharaID
-	mainCharaLevel := int64(12) // TODO: remove testing
+	mainCharaLevel := player.CharacterState[0].Level // TODO: is this right?
 	subCharaID := player.PlayerState.SubCharaID
-	subCharaLevel := int64(34) // TODO: remove testing
+	subCharaLevel := player.CharacterState[1].Level
 	mainChaoID := player.PlayerState.MainChaoID
-	mainChaoLevel := int64(5) // TODO: remove testing
+	mainChaoLevel := player.ChaoState[0].Level
 	subChaoID := player.PlayerState.SubChaoID
-	subChaoLevel := int64(6) // TODO: remove testing
+	subChaoLevel := player.ChaoState[1].Level
 	language := int64(enums.LangEnglish)
-	league := player.PlayerState.Rank // TODO: check if this is right
+	league := player.PlayerState.RankingLeague
 	maxScore := player.PlayerState.HighScore
+	if mode == 1 { //timed mode?
+		rankingScore = player.PlayerState.TimedHighScore
+		league = player.PlayerState.QuickRankingLeague
+		maxScore = player.PlayerState.TimedHighScore
+	}
 	return obj.LeaderboardEntry{
 		friendID,
 		name,

--- a/responses/leaderboard.go
+++ b/responses/leaderboard.go
@@ -71,7 +71,7 @@ func WeeklyLeaderboardEntries(base responseobjs.BaseInfo, pe obj.LeaderboardEntr
 func DefaultWeeklyLeaderboardEntries(base responseobjs.BaseInfo, player netobj.Player, mode int64) WeeklyLeaderboardEntriesResponse {
 	startTime := now.BeginningOfDay().UTC().Unix()
 	resetTime := startTime + 86400 // +1 Day
-	myEntry := conversion.PlayerToLeaderboardEntry(player)
+	myEntry := conversion.PlayerToLeaderboardEntry(player, mode)
 	return WeeklyLeaderboardEntries(
 		base,
 		//obj.DefaultLeaderboardEntry(uid),
@@ -82,7 +82,9 @@ func DefaultWeeklyLeaderboardEntries(base responseobjs.BaseInfo, player netobj.P
 		1,
 		mode,
 		0,
-		[]obj.LeaderboardEntry{},
+		[]obj.LeaderboardEntry{
+			myEntry,		
+		},
 	)
 }
 


### PR DESCRIPTION
This corrects some issues found on the continue screen, as well as showing the timed mode high score instead of the story mode high score on the timed mode results screen.